### PR TITLE
feat(schools): add delete school feature

### DIFF
--- a/app/controllers/schools_controller.rb
+++ b/app/controllers/schools_controller.rb
@@ -1,0 +1,26 @@
+class SchoolsController < ApplicationController
+  before_action :set_school, only: %i[destroy]
+
+  rescue_from ActiveRecord::RecordNotFound, with: :render_not_found
+
+  def destroy
+    if @school.destroy
+      render json: { message: "School #{@school.name_ar} destroyed" }, status: :ok
+    else
+      render json: { 
+        message: "School with id #{params[:id]} could not be destroyed", 
+        errors: @school.errors.full_messages 
+      }, status: :unprocessable_entity  
+    end
+  end
+
+  private
+
+  def set_school
+    @school = School.find(params[:id])
+  end
+
+  def render_not_found
+    render json: { error: "School not found with id #{params[:id]}" }, status: :not_found
+  end
+end

--- a/app/helpers/schools_helper.rb
+++ b/app/helpers/schools_helper.rb
@@ -1,0 +1,2 @@
+module SchoolsHelper
+end

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -1,0 +1,2 @@
+class School < ApplicationRecord
+end

--- a/app/views/schools/destroy.html.erb
+++ b/app/views/schools/destroy.html.erb
@@ -1,0 +1,2 @@
+<h1>Schools#destroy</h1>
+<p>Find me in app/views/schools/destroy.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get "schools/:id/destroy" => "schools#destroy"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/test/controllers/schools_controller_test.rb
+++ b/test/controllers/schools_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class SchoolsControllerTest < ActionDispatch::IntegrationTest
+  test "should get destroy" do
+    get schools_destroy_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/schools.yml
+++ b/test/fixtures/schools.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/school_test.rb
+++ b/test/models/school_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class SchoolTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
Refactored the destroy action in SchoolsController to handle record not found exceptions using rescue_from.

Added rescue_from ActiveRecord::RecordNotFound at the controller level to automatically catch missing records and respond with a JSON error message and 404 Not Found status.

Moved school fetching logic into a private set_school method with before_action to keep the controller DRY.

Improved JSON response consistency by returning:

Success message with status 200 OK when a school is deleted.

Error message with validation errors and status 422 Unprocessable Entity if deletion fails.

Not found error message with status 404 Not Found when the school does not exist.